### PR TITLE
add example files for how to split up the simulation jobs

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,20 @@
+# Efficient simulation of the training data
+
+Both the discoal step and the feature vector building steps
+can be time-consuming.  The most expedient way to address 
+that is to break the jobs up as much as possible.
+
+Here, we simulate training data using msprime for the coalescent
+simulations and discoal for the sweep simulations.
+We will simulate 50 replicates each of neutral, soft,
+and hard sweeps.  We will do the sims in batches of 5
+replicates per parameter combo.  Obviously, a real-world
+job would do many more replicates in total!
+
+We'll get the job done using GNU parallel.
+
+This directory has the following scripts:
+
+* `efficient_simulation.sh` breaks up the simulation and feature generation jobs and executes them via GNU parallel
+* `collate.sh` uses simple bash commands to bring the output from the previous steps together so that the training can be done.
+* `train.sh` runs the training step.  This script exists to show that the output from the previous two steps is usable.

--- a/examples/collate.sh
+++ b/examples/collate.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+NTRAINING=neutral_training.txt
+
+if [ -e $NTRAINING ]
+then
+    rm -f $NTRAINING
+fi
+I=0
+for i in simtemp/msprime*.fvec
+do
+    if [ $I -eq 0 ]
+    then
+        cat $i > $NTRAINING
+    else
+        # Strip the header
+        tail -n +2 $i >> $NTRAINING
+    fi
+    I=$(($I+1))
+done
+
+HDIR=hardTraining
+SDIR=softTraining
+
+if [ ! -d $HDIR ]
+then
+    mkdir $HDIR
+else
+    rm -f $HDIR/*
+fi
+
+if [ ! -d $SDIR ]
+then
+    mkdir $SDIR
+else
+    rm -f $SDIR/*
+fi
+
+WIN=0
+for sweep_pos in $(seq 0 0.1 1.0)
+do
+    HFILE=$HDIR/hard_$WIN.txt
+    SFILE=$SDIR/soft_$WIN.txt
+    I=0
+    for i in simtemp/hard_$WIN.*.fvec
+    do
+        if [ $I -eq 0 ]
+        then
+            cat $i > $HFILE
+        else
+            tail -n +2 $i >> $HFILE
+        fi
+        I=$(($I+1))
+    done
+
+    for i in simtemp/soft_$WIN.*.fvec
+    do
+        if [ $I -eq 0 ]
+        then
+            cat $i > $SFILE
+        else
+            tail -n +2 $i >> $SFILE
+        fi
+        I=$(($I+1))
+    done
+    WIN=$((WIN+1))
+done
+

--- a/examples/efficient_simulation.sh
+++ b/examples/efficient_simulation.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+DISCOALDIR=$HOME/src/discoal
+DIPLOSHICDIR=$HOME/src/diploSHIC
+NREPS_PER_BATCH=5
+SIMCOMMMANDSFILE=sim_commands.txt
+FVECCOMMANDSFILE=fvec_commands.txt
+SIMTEMPDIR=simtemp
+
+if [ -e $SIMCOMMMANDSFILE ]
+then
+    rm -f $SIMCOMMMANDSFILE
+fi
+
+if [ -e $FVECCOMMANDSFILE ]
+then
+    rm -f $FVECCOMMANDSFILE
+fi
+
+if [ ! -d $SIMTEMPDIR ]
+then
+    mkdir $SIMTEMPDIR
+else
+    # Clean out contents of our temp dir
+    rm -f $SIMTEMPDIR/*
+fi
+
+# Step 1: store msprime commands in a file and
+# the commands to build their feature vectors
+for i in $(seq 1 1 10)
+do
+    echo "mspms 100 $NREPS_PER_BATCH -t 1000 -r 1000 10000 --precision 10 --random-seeds $RANDOM $RANDOM $RANDOM > $SIMTEMPDIR/msprime_out.$i.txt" >> $SIMCOMMMANDSFILE
+    echo "python3 $DIPLOSHICDIR/diploSHIC.py fvecSim haploid $SIMTEMPDIR/msprime_out.$i.txt $SIMTEMPDIR/msprime_out.$i.fvec" >> $FVECCOMMANDSFILE
+done
+
+# Step 2: commands for hard and soft sweeps over a range of params 
+# and the commands to build the feature vectors
+WIN=0
+for sweep_pos in $(seq 0 0.1 1.0)
+do
+    for i in $(seq 1 1 10)
+    do
+        HARDFILE=$SIMTEMPDIR/hard_$WIN.batch$i.discoal
+        SOFTFILE=$SIMTEMPDIR/soft_$WIN.batch$i.discoal
+        echo "$DISCOALDIR/discoal 100 $NREPS_PER_BATCH 10000 -ws 0 -Pa 1000 2500 -x $sweep_pos -t 1000 -r 1000 > $HARDFILE" >> $SIMCOMMMANDSFILE
+        echo "$DISCOALDIR/discoal 100 $NREPS_PER_BATCH 10000 -ws 0 -Pa 1000 2500 -x $sweep_pos -Pf 0.1 0.5 -t 1000 -r 1000 > $SOFTFILE" >> $SIMCOMMMANDSFILE
+        b=`basename $HARDFILE .txt`
+        HARDTRAIN=$SIMTEMPDIR/$b.fvec
+        b=`basename $SOFTFILE .txt`
+        SOFTTRAIN=$SIMTEMPDIR/$b.fvec
+        echo "python3 $DIPLOSHICDIR/diploSHIC.py fvecSim haploid $HARDFILE $HARDTRAIN" >> $FVECCOMMANDSFILE
+        echo "python3 $DIPLOSHICDIR/diploSHIC.py fvecSim haploid $SOFTFILE $SOFTTRAIN" >> $FVECCOMMANDSFILE
+    done
+    WIN=$(($WIN+1))
+done
+
+# Step 3: let GNU parallel rip.
+# Note, on an HPC system, you would
+# probably execute this step as 
+# parallel --jobs $CORES, where $CORES
+# are the number of CPU/threads that the queuing
+# system assigned to your job. 
+# This command used here simply uses all available resources:
+parallel < $SIMCOMMMANDSFILE
+parallel < $FVECCOMMANDSFILE
+
+# Step 4: collate all the results into a SINGLE
+# feature vector file for  neutral, hard, soft

--- a/examples/train.sh
+++ b/examples/train.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+DIPLOSHICDIR=$HOME/src/diploSHIC
+
+if [ ! -d training_out ]
+then
+    mkdir training_out
+else
+    rm -f training_out/*
+fi
+
+python3 $DIPLOSHICDIR/diploSHIC.py makeTrainingSets neutral_training.txt softTraining/soft hardTraining/hard 5 0,1,2,3,4,6,7,8,9,10 training_out
+    
+python3 $DIPLOSHICDIR/diploSHIC.py train training_out/ training_out/ modelfile.txt
+


### PR DESCRIPTION
Adds a folder with a README and a few shell scripts.  The point is to show how to split up the feature vector calculation step when generating training data.  I do it all with vanilla bash + GNU parallel here.